### PR TITLE
Add /transcript endpoint. Remove outdated code.

### DIFF
--- a/functions/.eslintrc.cjs
+++ b/functions/.eslintrc.cjs
@@ -4,6 +4,9 @@ module.exports = {
     es2020: true,
     node: true,
   },
+  "parserOptions": {
+      "sourceType": "module"
+  },
   extends: [
     "eslint:recommended",
   ],

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -12,6 +12,7 @@
         "firebase-admin": "^11.11.0",
         "firebase-functions": "^5.0.1",
         "lodash": "^4.17.21",
+        "lodash.isequal": "^4.5.0",
         "youtubei.js": "^9.4.0"
       },
       "devDependencies": {
@@ -3793,6 +3794,11 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
@@ -8351,6 +8357,11 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "lodash.isinteger": {
       "version": "4.0.4",

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,7 @@
 {
   "name": "functions",
   "description": "Cloud Functions for Firebase",
+  "type": "module",
   "scripts": {
     "lint": "eslint .",
     "serve": "firebase emulators:start --only functions",
@@ -16,7 +17,7 @@
     "date-fns": "^2.30.0",
     "firebase-admin": "^11.11.0",
     "firebase-functions": "^5.0.1",
-    "lodash": "^4.17.21",
+    "lodash.isequal": "^4.5.0",
     "youtubei.js": "^9.4.0"
   },
   "private": true,


### PR DESCRIPTION
The /transcript endpoint allows the vast.ai server to post new transcripts using an access code.

This also upgrades from cjs to es6 module syntax and removes stale code.