### PR TITLE
Add in queue management APIs

### DIFF
--- a/functions/firebase_utils.js
+++ b/functions/firebase_utils.js
@@ -3,10 +3,22 @@ import { initializeApp } from 'firebase-admin/app';
 import { getDatabase } from 'firebase-admin/database';
 import { getStorage } from "firebase-admin/storage";
 import { getAuth } from 'firebase-admin/auth';
+import { onRequest } from "firebase-functions/v2/https";
 
 import { makePublicPath, makePrivatePath } from './utils.js';
 
 const STORAGE_BUCKET = 'sps-by-the-numbers.appspot.com';
+
+function jsonOnRequest(options, func) {
+  return onRequest(options, async (req, res) => {
+    try {
+      return func(req, res);
+    } catch (e) {
+      console.log(e);
+      return res.status(500).send(makeResponseJson(false, 'Exception'));
+    }
+  });
+}
 
 function getCategoryPublicDb(category) {
   return getDatabase().ref(makePublicPath(category));
@@ -34,4 +46,4 @@ async function verifyIdToken(token) {
   return await getAuth().verifyIdToken(token);
 }
 
-export { getCategoryPrivateDb, getCategoryPublicDb, getPubSubClient, getDefaultBucket, initializeFirebase, verifyIdToken };
+export { getCategoryPrivateDb, getCategoryPublicDb, getPubSubClient, getDefaultBucket, initializeFirebase, verifyIdToken, jsonOnRequest };

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,9 +1,9 @@
 import { speakerinfo } from './speakerinfo.js';
 import { metadata, transcript, start_transcribe } from './transcript.js';
-import { new_video_queue, find_new_videos } from './video_queue.js';
+import { video_queue } from './video_queue.js';
 
 import { initializeFirebase } from './firebase_utils.js';
 
 initializeFirebase();
 
-export { speakerinfo, metadata, find_new_videos, start_transcribe, transcript, new_video_queue };
+export { speakerinfo, metadata, start_transcribe, transcript, video_queue };

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,9 +1,9 @@
 import { speakerinfo } from './speakerinfo.js';
 import { metadata, transcript, start_transcribe } from './transcript.js';
-import { video_queue } from './video_queue.js';
+import { video_queue, vast } from './video_queue.js';
 
 import { initializeFirebase } from './firebase_utils.js';
 
 initializeFirebase();
 
-export { speakerinfo, metadata, start_transcribe, transcript, video_queue };
+export { speakerinfo, metadata, start_transcribe, transcript, video_queue, vast };

--- a/functions/transcript.js
+++ b/functions/transcript.js
@@ -35,7 +35,7 @@ const transcript = onRequest(
         return res.status(400).send(makeResponseJson(false, 'Missing vid'));
       }
 
-      const auth_code = (await getCategoryPrivateDb(req.body.category)
+      const auth_code = (await getCategoryPrivateDb('_admin')
           .child('vast').child(req.body.user_id).once("value")).val();
 
       if (req.body.auth_code !== auth_code) {

--- a/functions/utils.js
+++ b/functions/utils.js
@@ -17,4 +17,12 @@ function getAllCategories() {
   return [ 'sps-board', 'seattle-city-council'];
 }
 
-export { makeResponseJson, makePublicPath, makePrivatePath, getAllCategories };
+function sanitizeCategory(category) {
+  if (!category || category.length > 20) {
+    return undefined;
+  }
+
+  return category;
+}
+
+export { makeResponseJson, makePublicPath, makePrivatePath, getAllCategories, sanitizeCategory };

--- a/functions/video_queue.js
+++ b/functions/video_queue.js
@@ -1,74 +1,148 @@
-import { onRequest } from "firebase-functions/v2/https";
-import { makeResponseJson, getAllCategories } from './utils.js';
-import { getCategoryPublicDb, getCategoryPrivateDb, getPubSubClient } from './firebase_utils.js';
+import { makeResponseJson, getAllCategories, sanitizeCategory } from './utils.js';
+import { getCategoryPublicDb, getCategoryPrivateDb, getPubSubClient, jsonOnRequest } from './firebase_utils.js';
 import { getVideosForCategory } from './youtube.js';
 
-const new_video_queue = onRequest(
-  { cors: true, region: ["us-west1"] },
-  async (req, res) => {
-    if (req.method !== 'GET') {
-       return res.status(400).send(makeResponseJson(false, "Expects GET"));
-    }
-
-    const category = req.query.category;
-    if (!category || category.length > 20) {
-      return res.status(400).send(makeResponseJson(false, "Expects category"));
-    }
-
-    if (!req.query.user_id) {
-      return res.status(400).send(makeResponseJson(false, "missing user_id"));
-    }
-
-    const auth_code = (await getCategoryPrivateDb(req.query.category)
-        .child('vast').child(req.query.user_id).once("value")).val();
-
-    if (req.query.auth_code !== auth_code) {
-      return res.status(401).send(makeResponseJson(false, "invalid auth code"));
-    }
-
-    const new_vids = (await getCategoryPrivateDb(category).child('new_vids').once("value")).val();
-    return res.status(200).send(makeResponseJson(true, "New vids", new_vids));
+async function getVideoQueue(req, res) {
+  const category = sanitizeCategory(req.query.category);
+  if (!category) {
+    return res.status(400).send(makeResponseJson(false, "Expects category"));
   }
-);
 
-const find_new_videos = onRequest(
-  { cors: true, region: ["us-west1"] },
-  // TODO: Move this into new_vids and distinguis POST vs GET.
-  async (req, res) => {
-    if (req.method !== 'GET') {
-       return res.status(400).send(makeResponseJson(false, "Expects GET"));
-    }
+  if (!req.query.user_id) {
+    return res.status(400).send(makeResponseJson(false, "missing user_id"));
+  }
 
-    const all_new_vid_ids = [];
-    const add_ts = new Date();
-    let limit = 0;
-    // Can be empty in test and initial bootstrap.
-    for (const category of getAllCategories()) {
-      const metadata_ref = getCategoryPublicDb(category, 'metadata');
-      const metadata_snapshot = (await metadata_ref).once("value");
-      const new_video_ids = {};
+  const auth_code = (await getCategoryPrivateDb(req.query.category)
+      .child('vast').child(req.query.user_id).once("value")).val();
 
-      for (const vid of await getVideosForCategory(category)) {
-        if (req.query.limit && ++limit > req.query.limit) {
-          break;
-        }
+  if (req.query.auth_code !== auth_code) {
+    return res.status(401).send(makeResponseJson(false, "invalid auth code"));
+  }
 
-        if (!metadata_snapshot.child(vid.id).exists()) {
-          new_video_ids[vid.id] =  { add: add_ts, start: "", instance: "" };
-        }
+  const new_vids = (await getCategoryPrivateDb(category).child('new_vids').once("value")).val();
+  return res.status(200).send(makeResponseJson(true, "New vids", new_vids));
+}
+
+async function findNewVideos(req, res) {
+  const all_new_vid_ids = [];
+  const add_ts = new Date();
+
+  let limit = 0;
+  // Can be empty in test and initial bootstrap.
+  for (const category of getAllCategories()) {
+    const metadata_ref = getCategoryPublicDb(category, 'metadata');
+    const metadata_snapshot = await metadata_ref.once("value");
+    const new_video_ids = {};
+
+    for (const vid of await getVideosForCategory(category)) {
+      if (req.body.limit && ++limit > req.body.limit) {
+        break;
       }
 
-      all_new_vid_ids.push(...Object.keys(new_video_ids));
-      getCategoryPrivateDb(category).child('new_vids').update(new_video_ids);
+      if (!metadata_snapshot || !metadata_snapshot.child(vid.id).exists()) {
+        new_video_ids[vid.id] =  { add: add_ts, start: "", vast_instance: "" };
+      }
     }
 
-    // If there are new video ids. Wake up the trasncription jobs.
-    if (all_new_vid_ids) {
-      await getPubSubClient().topic("start_transcribe").publishMessage({data: Buffer.from("boo!")});
+    all_new_vid_ids.push(...Object.keys(new_video_ids));
+    getCategoryPrivateDb(category).child('new_vids').update(new_video_ids);
+  }
+
+  // If there are new video ids. Wake up the trasncription jobs.
+  if (all_new_vid_ids) {
+    await getPubSubClient().topic("start_transcribe").publishMessage({data: Buffer.from("boo!")});
+  }
+
+  return res.status(200).send(makeResponseJson(true, "vids enqueued", all_new_vid_ids));
+}
+
+async function removeItem(req, res) {
+  const category = sanitizeCategory(req.body.category);
+  if (!category) {
+    return res.status(400).send(makeResponseJson(false, "Expects category"));
+  }
+
+  // TODO: Extract this auth check.
+  if (!req.body.user_id) {
+    return res.status(400).send(makeResponseJson(false, "missing user_id"));
+  }
+
+  const auth_code = (await getCategoryPrivateDb('_admin')
+      .child('vast').child(req.body.user_id).once("value")).val();
+
+  if (req.body.auth_code !== auth_code) {
+    return res.status(401).send(makeResponseJson(false, "invalid auth code"));
+  }
+
+  const removes = []
+  for (const vid of req.body.video_ids) {
+    removes.push(getCategoryPrivateDb(category).child('new_vids').child(vid).remove());
+  }
+
+  await Promise.all(removes);
+
+  return res.status(200).send(makeResponseJson(true, "Items removed"));
+}
+
+async function updateEntry(req, res) {
+  const category = sanitizeCategory(req.body.category);
+  if (!category) {
+    return res.status(400).send(makeResponseJson(false, "Expects category"));
+  }
+
+  // TODO: Extract this auth check.
+  if (!req.body.user_id) {
+    return res.status(400).send(makeResponseJson(false, "missing user_id"));
+  }
+
+  const auth_code = (await getCategoryPrivateDb('_admin')
+      .child('vast').child(req.body.user_id).once("value")).val();
+
+  if (req.body.auth_code !== auth_code) {
+    return res.status(401).send(makeResponseJson(false, "invalid auth code"));
+  }
+
+  if (!req.body.vast_instance) {
+    return res.status(400).send(makeResponseJson(false, "missing vast_instance"));
+  }
+
+  const started_ts = new Date();
+
+  const queue_ref = getCategoryPrivateDb(category).child('new_vids');
+  const existing_vids = (await queue_ref.once("value")).val();
+  const all_sets = [];
+  const updated_ids = [];
+  for (const vid of req.body.video_ids) {
+    if (vid in existing_vids) {
+      updated_ids.push(vid);
+      all_sets.push(queue_ref.child(vid).set(
+            { ...existing_vids[vid],
+              vast_instance: req.body.vast_instance,
+              start: started_ts.toISOString(),
+            }));
+    }
+  }
+
+  await Promise.all(all_sets);
+
+  return res.status(200).send(makeResponseJson(true, "Items updated", {updated_ids}));
+}
+
+const video_queue = jsonOnRequest(
+  { cors: true, region: ["us-west1"] },
+  async (req, res) => {
+    if (req.method === 'GET') {
+       return getVideoQueue(req, res);
+    } else if (req.method === 'POST') {
+       return findNewVideos(req, res);
+    } else if (req.method === 'PATCH') {
+       return updateEntry(req, res);
+    } else if (req.method === 'DELETE') {
+       return removeItem(req, res);
     }
 
-    return res.status(200).send(makeResponseJson(true, "vids enqueued", all_new_vid_ids));
+    return res.status(405).send(makeResponseJson(false, 'Method Not Allowed'));
   }
 );
 
-export { new_video_queue, find_new_videos }
+export { video_queue }

--- a/functions/youtube.js
+++ b/functions/youtube.js
@@ -24,8 +24,8 @@ async function getVideosForCategory(category) {
       feed = await videos.getContinuation();
     }
   } else if (category === "seattle-city-council") {
-    const playlist = await youtube.getPlaylist("PLhfhh0Ed-ZC2d0zuuzyCf1gaPaKfH4k4f");
-    feed = playlist.items();
+    feed = await youtube.getPlaylist("PLhfhh0Ed-ZC2d0zuuzyCf1gaPaKfH4k4f");
+    results.push(...feed.videos);
   }
 
   while (feed?.has_continuation) {


### PR DESCRIPTION
Make it possible for instances to update queue items with when processing has started and by whom.

Also allows deletion of queue items and vast instances.

With this, the API should be ready for use by a Vast.ai instance.