### PR TITLE
Overengineer date range defaulting

### DIFF
--- a/app/Transcripts.tsx
+++ b/app/Transcripts.tsx
@@ -10,11 +10,13 @@ import { VideoData, getAllVideosForDateRange } from 'utilities/metadata-utils';
 import { formatDateForPath, getVideoPath, parseDateFromPath } from 'utilities/path-utils';
 import LoadingSpinner from 'components/LoadingSpinner';
 
-const defaultCategory = 'sps-board';
-const defaultDate = parseDateFromPath('2024-03-01');
+type Props = {
+  allCategories: string[],
+  defaultFilters: TranscriptFilterSelection
+};
 
-export default function Transcripts({ allCategories }: { allCategories: string[] }) {
-  const { filterParams, updateFilterParams } = useFilterParams(allCategories);
+export default function Transcripts({ allCategories, defaultFilters}: Props) {
+  const { filterParams, updateFilterParams } = useFilterParams(allCategories, defaultFilters);
   const [filters, updateFilters]: [TranscriptFilterSelection, any] = useState(filterParams);
   const { videos, isLoading } = useFilteredVideos(filters);
 
@@ -54,7 +56,7 @@ export default function Transcripts({ allCategories }: { allCategories: string[]
   );
 }
 
-function useFilterParams(allCategories: string[]): {
+function useFilterParams(allCategories: string[], defaultFilter: TranscriptFilterSelection): {
    filterParams: TranscriptFilterSelection,
    updateFilterParams: (newFilters: TranscriptFilterSelection) => void
 } {
@@ -63,8 +65,8 @@ function useFilterParams(allCategories: string[]): {
   const { push } = useRouter();
 
   const filterParams: TranscriptFilterSelection = {
-    category: getCategoryFromParams(searchParams, allCategories),
-    dateRange: getDateRangeFromParams(searchParams),
+    category: getCategoryFromParams(searchParams, allCategories, defaultFilter.category),
+    dateRange: getDateRangeFromParams(searchParams, defaultFilter.dateRange),
   };
 
   const updateFilterParams = (newFilters: TranscriptFilterSelection) => {
@@ -115,7 +117,7 @@ function useFilteredVideos(filters: TranscriptFilterSelection): {
   return { videos, isLoading };
 }
 
-function getCategoryFromParams(params: URLSearchParams, allCategories: string[]): string {
+function getCategoryFromParams(params: URLSearchParams, allCategories: string[], defaultCategory: string): string {
   const categoryParam: string | null = params.get('category');
 
   if (categoryParam !== null && allCategories.includes(categoryParam)) {
@@ -125,12 +127,12 @@ function getCategoryFromParams(params: URLSearchParams, allCategories: string[])
   return defaultCategory;
 }
 
-function getDateRangeFromParams(params: URLSearchParams): DateRange {
+function getDateRangeFromParams(params: URLSearchParams, defaultRange: DateRange): DateRange {
   const start: Date | null = getDateFromParams(params, 'start');
   const end: Date | null = getDateFromParams(params, 'end');
 
   if (start === null && end === null) {
-    return { start: defaultDate, end: null };
+    return defaultRange;
   }
 
   return { start, end };

--- a/app/Transcripts.tsx
+++ b/app/Transcripts.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { isValid } from 'date-fns';
+import { compareDesc, isValid } from 'date-fns';
 
 import TranscriptFilter, { TranscriptFilterSelection, DateRange } from 'components/TranscriptFilter';
 import { VideoData, getAllVideosForDateRange } from 'utilities/metadata-utils';
@@ -23,8 +23,9 @@ export default function Transcripts({ allCategories }: { allCategories: string[]
     updateFilterParams(filters);
   }
 
-  const videoLinks: React.ReactNode[] = videos.map(
-    video => (
+  const videoLinks: React.ReactNode[] = videos
+    .sort((a, b) => compareDesc(a.publishDate, b.publishDate))
+    .map(video => (
       <li key={video.videoId} className="mx-3 list-disc">
         <Link href={getVideoPath(filters.category, video.videoId)}>
           {video.title}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 import { getAllCategories, getLastDateForCategory } from 'utilities/metadata-utils';
-import Transcripts from './Transcripts';
+import Transcripts, { DefaultFiltersByCategory } from './Transcripts';
 import { TranscriptFilterSelection } from 'components/TranscriptFilter';
 import { startOfMonth, subMonths } from 'date-fns';
 
@@ -7,20 +7,19 @@ const defaultCategory = 'sps-board';
 
 export default async function Index() {
   const allCategories: string[] = await getAllCategories();
-  const lastDate: Date | null = await getLastDateForCategory(defaultCategory);
-  const start: Date | null = lastDate !== null ? startOfMonth(subMonths(lastDate, 1)) : null
 
-  const defaultFilters: TranscriptFilterSelection = {
-    category: defaultCategory,
-    dateRange: {
-      start,
-      end: null
-    }
-  };
+  const defaultsByCategory: DefaultFiltersByCategory = {};
+
+  for (const category of allCategories) {
+    const lastDate: Date | null = await getLastDateForCategory(defaultCategory);
+    const start: Date | null = lastDate !== null ? startOfMonth(subMonths(lastDate, 1)) : null
+
+    defaultsByCategory[category] = { defaultStart: start };
+  }
 
   return (
     <main className="mx-5 my-5 max-w-screen-md">
-      <Transcripts allCategories={allCategories} defaultFilters={defaultFilters} />
+      <Transcripts defaultCategory={defaultCategory} defaultsByCategory={defaultsByCategory} />
     </main>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,26 @@
-import { getAllCategories } from 'utilities/metadata-utils';
+import { getAllCategories, getLastDateForCategory } from 'utilities/metadata-utils';
 import Transcripts from './Transcripts';
+import { TranscriptFilterSelection } from 'components/TranscriptFilter';
+import { startOfMonth, subMonths } from 'date-fns';
+
+const defaultCategory = 'sps-board';
 
 export default async function Index() {
   const allCategories: string[] = await getAllCategories();
+  const lastDate: Date | null = await getLastDateForCategory(defaultCategory);
+  const start: Date | null = lastDate !== null ? startOfMonth(subMonths(lastDate, 1)) : null
+
+  const defaultFilters: TranscriptFilterSelection = {
+    category: defaultCategory,
+    dateRange: {
+      start,
+      end: null
+    }
+  };
+
   return (
     <main className="mx-5 my-5 max-w-screen-md">
-      <Transcripts allCategories={allCategories} />
+      <Transcripts allCategories={allCategories} defaultFilters={defaultFilters} />
     </main>
   );
 }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/utilities/metadata-utils.ts
+++ b/utilities/metadata-utils.ts
@@ -1,6 +1,7 @@
-import { get, child, QueryConstraint, startAt, endAt, query, DataSnapshot, orderByKey } from "firebase/database"
+import { get, child, QueryConstraint, startAt, endAt, query, DataSnapshot, orderByKey, limitToLast } from "firebase/database"
 import { dbPublicRoot } from 'utilities/firebase';
 import { parseISO } from 'date-fns';
+import { parseDateFromPath } from "./path-utils";
 
 export type VideoData = {
     videoId: string,
@@ -49,6 +50,25 @@ export async function getDatesForCategory(category: string): Promise<string[]> {
       return [];
     }
     return Object.keys(result);
+}
+
+export async function getLastDateForCategory(category: string): Promise<Date | null> {
+  const data: DataSnapshot = await get(query(
+    child(dbPublicRoot, `${category}/index/date`),
+    orderByKey(),
+    limitToLast(1)));
+
+  const dataVal: {
+    [dateString: string]: any
+  } = data.val();
+
+  const datePaths: string[] = Object.keys(dataVal);
+
+  if (datePaths.length === 0) {
+    return null;
+  }
+
+  return parseDateFromPath(datePaths[0]);
 }
 
 export async function getAllVideosForPublishDate(category: string, datePath: string): Promise<VideoData[]> {


### PR DESCRIPTION
Default date range selection is now determined by the most recent publication date, and goes back to the start of the previous month. This is also broken down by category, so if one category gets a lot of activity while the other is on a break, you don't just get an empty page.