### PR TITLE
Start moving Firebase DB calls behind a clouds function

### DIFF
--- a/app/[category]/v/[prefix]/[videoId]/[lang]/page.tsx
+++ b/app/[category]/v/[prefix]/[videoId]/[lang]/page.tsx
@@ -5,7 +5,7 @@ import { DiarizedTranscript } from "common/transcript"
 import { Metadata, ResolvingMetadata } from "next"
 import { Storage } from '@google-cloud/storage';
 import { SupportedLanguages } from 'common/languages';
-import { getMetadata } from "utilities/metadata-utils"
+import { getMetadata } from "utilities/client/metadata"
 import { loadSpeakerControlInfo } from 'utilities/client/speaker'
 import { storageAccessor } from "utilities/firebase"
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
-import { getAllCategories, getLastDateForCategory } from 'utilities/metadata-utils';
+import * as Constants from 'config/constants';
+import { getLastDateForCategory } from 'utilities/metadata-utils';
 import Transcripts, { DefaultFiltersByCategory } from './Transcripts';
 import { TranscriptFilterSelection } from 'components/TranscriptFilter';
 import { startOfMonth, subMonths } from 'date-fns';
@@ -6,11 +7,9 @@ import { startOfMonth, subMonths } from 'date-fns';
 const defaultCategory = 'sps-board';
 
 export default async function Index() {
-  const allCategories: string[] = await getAllCategories();
-
   const defaultsByCategory: DefaultFiltersByCategory = {};
 
-  for (const category of allCategories) {
+  for (const category of Constants.ALL_CATEGORIES) {
     const lastDate: Date | null = await getLastDateForCategory(defaultCategory);
     const start: Date | null = lastDate !== null ? startOfMonth(subMonths(lastDate, 1)) : null
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,5 +1,6 @@
+import * as Constants from 'config/constants';
 import { MetadataRoute } from 'next';
-import { getAllCategories, getAllVideosForCategory, getDatesForCategory } from 'utilities/metadata-utils';
+import { getAllVideosForCategory, getDatesForCategory } from 'utilities/metadata-utils';
 import { getCategoryPath, getDatePath, getVideoPath } from 'utilities/path-utils';
 
 type ChangeFrequency = 'always' | 'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly' | 'never';
@@ -19,11 +20,9 @@ function buildUrl(relativePath): string {
 }
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const categories: string[] = await getAllCategories();
-
   const videoPages: SiteMapEntry[] = [];
 
-  for (const category of categories) {
+  for (const category of Constants.ALL_CATEGORIES) {
     const videos = await getAllVideosForCategory(category);
 
     videoPages.push(...videos.map(v => ({

--- a/app/tehpower/add_video/page.tsx
+++ b/app/tehpower/add_video/page.tsx
@@ -1,9 +1,9 @@
 'use client'
 
+import * as Constants from 'config/constants';
 import { app } from 'utilities/firebase'
 import { getAuth, signInWithPopup, GoogleAuthProvider } from "firebase/auth"
 import { initializeAppCheck, ReCaptchaV3Provider } from "firebase/app-check"
-import { getAllCategories } from 'utilities/metadata-utils'
 import { useState, useEffect } from 'react'
 
 type SubmitStatus = {

--- a/components/SpeakerInfoControl.tsx
+++ b/components/SpeakerInfoControl.tsx
@@ -7,6 +7,7 @@ import CreatableSelect from 'react-select/creatable'
 import { app } from 'utilities/firebase'
 import { getAuth, signInWithPopup, GoogleAuthProvider } from "firebase/auth"
 import { getSpeakerAttributes, toSpeakerKey, SpeakerInfoData } from 'utilities/speaker-info'
+import { fetchEndpoint } from 'utilities/client/endpoint'
 import { initializeAppCheck, ReCaptchaV3Provider } from "firebase/app-check"
 import { isEqual } from 'lodash-es'
 import { toSpeakerNum } from "utilities/speaker-info"
@@ -155,15 +156,9 @@ export default function SpeakerInfoControl({category, className, speakerNums, vi
 
     setSubmitStatus({...submitStatus, has_submitted: true, in_progress: true});
 
-    fetch(Constants.ENDPOINTS['speakerinfo'],
-      {
-        method: "POST",
-        headers: {
-          'Accept': 'application/json, text/plain, */*',
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(data)
-      }).then(response => setSubmitStatus({has_submitted: true, in_progress: false, last_status: response.status}));
+    const response = await fetchEndpoint('speakerinfo', 'POST', data);
+
+    setSubmitStatus({has_submitted: true, in_progress: false, last_status: response.status});
   }
 
   // Must be deleted once
@@ -202,7 +197,7 @@ export default function SpeakerInfoControl({category, className, speakerNums, vi
     // key is the counterpart to the secret key you set in the Firebase console.
     if (!appCheck) {
       appCheck = initializeAppCheck(app, {
-        provider: new ReCaptchaV3Provider('6LfukwApAAAAAOysCMfJontBc36O2vly91NWpip8'),
+        provider: new ReCaptchaV3Provider(Constants.RECAPTCHA_KEY),
 
         // Optional argument. If true, the SDK automatically refreshes App Check
         // tokens as needed.

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -51,13 +51,17 @@ export const FIREBASE_CLIENT_CONFIG = {
   measurementId: "G-WKM5FTSSLL"
 };
 
+// Used by appcheck.
+export const RECAPTCHA_KEY = '6LfukwApAAAAAOysCMfJontBc36O2vly91NWpip8';
+
 // Generate URLs for use in fetch() calls based on envrionment type.
 const ENDPOINT_NAMES = [
+  'metadata',
   'sentences',
   'speakerinfo',
-  'transcript',
   'vast',
   'video_queue',
+  'transcript',
 ];
 
 // List of production endpoint names.

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -74,6 +74,7 @@ export const ENDPOINTS = isProduction ? PRODUCTION_ENDPOINTS : TEST_ENDPOINTS;
 export const TOP_LANGUAGES = [
   'eng',
   'spa',
+  'som',
   'zho-HANS',
   'zho-HANT',
   'vie',

--- a/functions/package.json
+++ b/functions/package.json
@@ -8,7 +8,7 @@
     "build:tsc": "tsc",
     "build:watch": "run-p 'build:tsc -- --watch --preserveWatchOutput' 'build:esbuild -- --watch'",
     "dev": "run-p build:watch dev:*",
-    "dev:emulators": "firebase emulators:start --only functions,database",
+    "dev:emulators": "firebase emulators:start --only functions",
     "lint": "eslint --ext .js,.ts .",
     "serve": "npm run build && firebase emulators:start --only functions,storage,database",
     "shell": "npm run build && firebase functions:shell",

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,9 +1,10 @@
 import 'source-map-support/register.js';
 
+export { metadata } from "./metadata";
+export { sentences } from "./sentences";
 export { speakerinfo } from "./speakerinfo";
 export { transcript } from "./transcript";
 export { video_queue, vast } from "./video_queue";
-export { sentences } from "./sentences";
 
 import { initializeFirebase } from "./utils/firebase";
 

--- a/functions/src/metadata.ts
+++ b/functions/src/metadata.ts
@@ -1,0 +1,35 @@
+import { getCategoryPublicDb, jsonOnRequest } from "./utils/firebase";
+import { makeResponseJson } from "./utils/response";
+
+async function getMetadata(req, res) {
+  const category = req.query.category;
+  if (!category || category.length > 20) {
+    return res.status(400).send(makeResponseJson(false, "Expects category"));
+  }
+
+  if (!req.query.videoId) {
+    return res.status(400).send(makeResponseJson(false, "missing videoId"));
+  }
+
+  const result = (await getCategoryPublicDb(category)
+      .child(`metadata`)
+      .child(req.query.videoId)
+      .once("value")).val();
+  if (!result) {
+     console.log("blah, ", result);
+    return res.status(400).send(makeResponseJson(false, "no metadata for videoId"));
+  }
+
+  return res.status(200).send(makeResponseJson(true, "ok", result));
+}
+
+export const metadata = jsonOnRequest(
+  {cors: true, region: ["us-west1"]},
+  async (req, res) => {
+    if (req.method === "GET") {
+      return getMetadata(req, res);
+    }
+
+    return res.status(405).send(makeResponseJson(false, "Method Not Allowed"));
+  }
+);

--- a/functions/src/transcript.ts
+++ b/functions/src/transcript.ts
@@ -93,13 +93,13 @@ async function downloadTranscript(req, res) {
 }
 
 function setMetadata(category, metadata) {
-  const category_public = getCategoryPublicDb(category);
   if (!metadata || !metadata["video_id"]) {
     console.log("Invalid metadata: ", metadata);
     return false;
   }
 
   const video_id = metadata["video_id"];
+  const category_public = getCategoryPublicDb(category);
   category_public.child("metadata").child(video_id).set(metadata);
 
   // Add to the index.

--- a/functions/src/utils/path.ts
+++ b/functions/src/utils/path.ts
@@ -1,7 +1,3 @@
-export function getAllCategories() {
-  return ["sps-board", "seattle-city-council"];
-}
-
 export function sanitizeCategory(category) {
   if (!category || category.length > 20) {
     return undefined;

--- a/functions/src/video_queue.test.ts
+++ b/functions/src/video_queue.test.ts
@@ -1,13 +1,13 @@
+import * as Constants from 'config/constants';
 import * as TestingUtils from './utils/testing';
 import { getCategoryPrivateDb } from './utils/firebase';
-import { getAllCategories } from './utils/path';
 
 describe('video_queue', () => {
   beforeAll(TestingUtils.beforeAll);
 
   it.skip('Access with auth_code', async () => {
     const NEW_VIDS = ['a','b','c'];
-    const category = getAllCategories()[0];
+    const category = Constants.ALL_CATEGORIES[0];
     getCategoryPrivateDb(category, 'new_vids').set(NEW_VIDS);
     const response = await TestingUtils.fetchEndpoint(
         'video_queue',

--- a/functions/src/video_queue.ts
+++ b/functions/src/video_queue.ts
@@ -1,6 +1,8 @@
 import { getCategoryPublicDb, getCategoryPrivateDb, getPubSubClient, jsonOnRequest, getAuthCode, getUser, UserRecord } from "./utils/firebase";
+import * as Constants from 'config/constants';
+
 import { getVideosForCategory } from "./youtube.js";
-import { getAllCategories, sanitizeCategory } from "./utils/path";
+import { sanitizeCategory } from "./utils/path";
 import { makeResponseJson } from "./utils/response";
 
 async function getVideoQueue(req, res) {
@@ -14,7 +16,7 @@ async function getVideoQueue(req, res) {
   }
 
   const new_vids = {};
-  for (const category of getAllCategories()) {
+  for (const category of Constants.ALL_CATEGORIES) {
     const category_vids = (await getCategoryPrivateDb(category).child("new_vids").once("value")).val();
     if (category_vids) {
       new_vids[category] = category_vids;
@@ -32,7 +34,7 @@ async function findNewVideos(req, res) {
 
   let limit = 0;
   // Can be empty in test and initial bootstrap.
-  for (const category of getAllCategories()) {
+  for (const category of Constants.ALL_CATEGORIES) {
     const metadata_ref = getCategoryPublicDb(category, "metadata");
     const metadata_snapshot = await metadata_ref.once("value");
     const new_video_ids = {};

--- a/utilities/client/endpoint.ts
+++ b/utilities/client/endpoint.ts
@@ -1,0 +1,19 @@
+// Simple utilities for talking to REST APIs.
+
+import * as Constants from 'config/constants';
+
+export async function fetchEndpoint(endpoint : string, method: string, parameters : Record<string,string> | object) {
+  const urlRoot = `${Constants.ENDPOINTS[endpoint]}`;
+  if (method === 'GET') {
+    const fullUrl = urlRoot + '?' + new URLSearchParams(<Record<string, string>>parameters).toString();
+    return await (await fetch(fullUrl)).json();
+  }
+
+  return await (await fetch(urlRoot, {
+      method,
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(parameters),
+  })).json();
+}

--- a/utilities/client/metadata.ts
+++ b/utilities/client/metadata.ts
@@ -1,0 +1,9 @@
+import { fetchEndpoint } from 'utilities/client/endpoint';
+
+export async function getMetadata(category: string, videoId: string): Promise<any> {
+    const response = await fetchEndpoint('metadata', 'GET', {category, videoId});
+    if (!response.ok) {
+      throw response;
+    }
+    return response.data;
+}

--- a/utilities/client/speaker.ts
+++ b/utilities/client/speaker.ts
@@ -1,4 +1,5 @@
-import { getExistingRef, getVideoRef } from "utilities/metadata-utils"
+import { getCategoryPublicRoot } from "utilities/metadata-utils"
+
 import type { SpeakerInfoData } from 'utilities/speaker-info'
 
 type SpeakerControlInfo = {
@@ -11,6 +12,14 @@ type DbInfoEntry ={
   name : string;
   tags : Array<string>;
 };
+
+async function getVideoRef(category: string, id: string): Promise<any> {
+    return (await getCategoryPublicRoot(category)).child(`v/${id}`);
+}
+
+async function getExistingRef(category: string): Promise<any> {
+    return (await getCategoryPublicRoot(category)).child('existing');
+}
 
 export async function loadSpeakerControlInfo(category: string, videoId: string) : Promise<SpeakerControlInfo> {
   const videoRef = await getVideoRef(category, videoId);

--- a/utilities/metadata-utils.ts
+++ b/utilities/metadata-utils.ts
@@ -25,12 +25,6 @@ export async function getCategoryPublicRoot(category: string): Promise<any> {
     return (await get(dbPublicRoot)).child(category);
 }
 
-export async function getAllCategories(): Promise<string[]> {
-    const result = (await get(dbPublicRoot)).val();
-
-    return Object.keys(result);
-}
-
 export async function getAllVideosForCategory(category: string): Promise<VideoData[]> {
     const result = (await getCategoryPublicRoot(category)).child(`metadata`).val();
     if (!result) {
@@ -102,16 +96,4 @@ export async function getAllVideosForDateRange(
     );
 
     return videos;
-}
-
-export async function getMetadata(category: string, id: string): Promise<any> {
-    return (await getCategoryPublicRoot(category)).child(`metadata/${id}`).val();
-}
-
-export async function getVideoRef(category: string, id: string): Promise<any> {
-    return (await getCategoryPublicRoot(category)).child(`v/${id}`);
-}
-
-export async function getExistingRef(category: string): Promise<any> {
-    return (await getCategoryPublicRoot(category)).child('existing');
 }


### PR DESCRIPTION
The Firebase database usage is out of control. Within 2 days of crawling from bing, it racked up 76GB of data download when the _entire_ database size is 3MB.

The guess is there is a mistake in how the DB is being used by the client code causing lack of caching and other stuff.

This is the start of trying to normalize all the database calls in to one spot while reducing the dependence on the database for effectively static information.  Over time, will move the metadata so that it queries youtube directly instead of copying it, and then the speaker labels should be moved back into cloud storage.