### PR TITLE
Extract a new image for indexing

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -34,3 +34,14 @@ jobs:
           file: Dockerfile.search
           push: false
           tags: search
+
+  build-index:
+    name: Build index
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/build-push-action@v6
+        with:
+          file: Dockerfile.index
+          push: false
+          tags: index

--- a/Dockerfile.index
+++ b/Dockerfile.index
@@ -1,0 +1,24 @@
+FROM node:lts
+
+# File locations.
+ENV SEARCH_DIR=/search
+ENV SEARCH_DB=${SEARCH_DIR}/data.ms
+ARG APP_DIR=/app
+
+#COPY /meili_data/dumps/20250120-081408619.dump /meili_data/dumps/latest.dump
+
+WORKDIR ${SEARCH_DIR}
+RUN <<EOF
+curl -L https://install.meilisearch.com | sh
+EOF
+
+WORKDIR ${APP_DIR}
+COPY package.json package-lock.json ${APP_DIR}
+
+RUN <<EOF
+npm install
+npm install -y tsx
+EOF
+
+COPY . ${APP_DIR}
+WORKDIR ${APP_DIR}

--- a/Dockerfile.search
+++ b/Dockerfile.search
@@ -1,61 +1,8 @@
-FROM node:lts
-
-# File locations.
-ARG SEARCH_DIR=/search
-ARG SEARCH_DB=${SEARCH_DIR}/data.ms
-ARG APP_DIR=/app
-ARG MASTER_KEY=masterKey
-
-#COPY /meili_data/dumps/20250120-081408619.dump /meili_data/dumps/latest.dump
-
-WORKDIR ${SEARCH_DIR}
-RUN <<EOF
-curl -L https://install.meilisearch.com | sh
-EOF
-
-WORKDIR ${APP_DIR}
-COPY package.json package-lock.json ${APP_DIR}
-
-RUN <<EOF
-npm install
-npm install -y tsx
-EOF
-
-COPY . ${APP_DIR}
-WORKDIR ${APP_DIR}
-
-# Load the dump and create the database while also initializing the keys.
-RUN <<EOF
-set -x
-nohup ${SEARCH_DIR}/meilisearch --db-path=$SEARCH_DB --master-key="$MASTER_KEY" &
-SEARCH_PID=$!
-
-# Wait until health check comes back witgh 200.
-until curl -X -f -o /dev/null "http://127.0.0.1:7700/health"
-do
-  sleep 1
-done
-
-# Register the key UID. The same (Master Key, UID) pair will generate the same key.
-until curl -X POST -H "Content-Type: application/json" --data-binary '{"name":"Transcript Front Search", "description":"Transcript Frontend Search Access", "uid": "fa82128d-a898-42ca-86eb-0e056195a111", "actions": ["search"], "indexes":["*"], "expiresAt": null}' -H "Authorization: Bearer $MASTER_KEY" -s -f -o /dev/null "http://127.0.0.1:7700/keys"
-do
-  sleep 1
-done
-
-# Recreate index
-npx tpx tools/search/setup.mts
-npx tpx tools/search/recreate_index.mts
-
-# Kill the meilisearch instance.
-kill -INT $SEARCH_PID
-EOF
-
-
 FROM getmeili/meilisearch:latest
 
 ARG SEARCH_DB
 
 ENTRYPOINT ["tini", "--"]
 EXPOSE 7700
-COPY --from=0 $SEARCH_DB /meili_data/data.ms
-CMD ["/bin/meilisearch", "--master-key=masterKey"]
+COPY tools/search/start_meilisearch.sh /
+CMD ["/start_meilisearch.sh"]

--- a/tools/search/client.mts
+++ b/tools/search/client.mts
@@ -5,7 +5,7 @@ export const client = new MeiliSearch({
   //host: 'https://meilisearch-rdcihhc4la-uw.a.run.app',
 //  apiKey: 'fcb72b464bc4d53e1e6b69a315607874daf5e9880b5f41c1bda96a4172dc3518', // Read
   //apiKey: '4b1daea39477fa19f03762276bf69fd3ce1618ee5fd7a9bd97ff5d5999e4c7d0', // Write
-  apiKey: 'masterKey',
+  apiKey: process.env.MASTER_KEY,
 });
 
 export function getIndexName(category: CategoryId, lang: Iso6393Code) {

--- a/tools/search/recreate_index.sh
+++ b/tools/search/recreate_index.sh
@@ -1,0 +1,28 @@
+#! /bin/bash
+set -euo pipefail
+
+export MASTER_KEY=$(cat /run/secrets/meilisearch)
+
+nohup ${SEARCH_DIR}/meilisearch --db-path=$SEARCH_DB --master-key="$MASTER_KEY" &
+SEARCH_PID=$!
+
+# Wait until health check comes back with 200.
+until curl -X -f "http://127.0.0.1:7700/health"
+do
+  sleep 1
+done
+
+# Register the key UID. The same (Master Key, UID) pair will generate the same key.
+until curl -X POST -H "Content-Type: application/json" --data-binary '{"name":"Transcript Front Search", "description":"Transcript Frontend Search Access", "uid": "fa82128d-a898-42ca-86eb-0e056195a111", "actions": ["search"], "indexes":["*"], "expiresAt": null}' -H "Authorization: Bearer $MASTER_KEY" -s -f -o /dev/null "http://127.0.0.1:7700/keys"
+do
+  sleep 1
+done
+
+# Recreate index
+npx tsx tools/search/setup.mts
+npx tsx tools/search/recreate_index.mts
+
+ls -l $SEARCH_DB
+
+# Kill the meilisearch instance.
+kill -INT $SEARCH_PID

--- a/tools/search/start_meilisearch.sh
+++ b/tools/search/start_meilisearch.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+set -euo pipefail
+
+# TODO: download stuff from Google Cloud Storage to /meili_data/data.ms
+
+exec /bin/meilisearch --master-key=$(cat /run/secrets/meilisearch)


### PR DESCRIPTION
Instead of embedding Meilisearch's master key, this new index image can be used like below, in the local development environment.

```
docker run --network host -ti -v "$(pwd)/secrets:/run/secrets" index /app/tools/search/recreate_index.sh
```

It should work in Cloud Run, but I haven't tested.