### PR TITLE
Make Dockerfile.search work on Cloud Run

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -31,3 +31,25 @@ jobs:
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  build-search:
+    name: Build search
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/search
+      - uses: actions/checkout@v4
+      - uses: docker/build-push-action@v6
+        with:
+          file: Dockerfile.search
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,14 +24,3 @@ jobs:
           context: tools/process_new_vids
           push: false
           tags: transcribe-worker
-
-  build-search:
-    name: Build search
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: docker/build-push-action@v6
-        with:
-          file: Dockerfile.search
-          push: false
-          tags: search

--- a/Dockerfile.search
+++ b/Dockerfile.search
@@ -1,6 +1,16 @@
-FROM getmeili/meilisearch:latest
+FROM getmeili/meilisearch:v1.14
 
-ARG SEARCH_DB
+ARG GOOGLE_CLOUD_CLI_VERSION=522.0.0
+
+RUN <<EOF
+apk add --no-cache python3
+curl --silent https://storage.googleapis.com/cloud-sdk-release/google-cloud-cli-${GOOGLE_CLOUD_CLI_VERSION}-linux-x86_64.tar.gz | tar zxf - -C /opt
+/opt/google-cloud-sdk/install.sh --quiet
+EOF
+
+ENV PATH="/opt/google-cloud-sdk/bin:$PATH"
+ENV SEARCH_DIR=/search
+ENV SEARCH_DB=${SEARCH_DIR}/data.ms
 
 ENTRYPOINT ["tini", "--"]
 EXPOSE 7700

--- a/tools/search/start_meilisearch.sh
+++ b/tools/search/start_meilisearch.sh
@@ -1,6 +1,21 @@
-#! /bin/bash
+#! /bin/sh
 set -euo pipefail
 
-# TODO: download stuff from Google Cloud Storage to /meili_data/data.ms
+# gcp_key_path is for testing this image outside of Cloud Run.
+# On Cloud Run, permissions are granted via the service account of the job.
+gcp_key_path=/run/secrets/gcp.json
+if [[ -e "$gcp_key_path" ]]; then
+    gcloud auth activate-service-account "--key-file=$gcp_key_path"
+fi
 
-exec /bin/meilisearch --master-key=$(cat /run/secrets/meilisearch)
+# This key is for testing.
+# The key must be at least 16 bytes long.
+# https://www.meilisearch.com/docs/learn/security/basic_security#creating-the-master-key-in-a-self-hosted-instance
+MASTER_KEY='MEILI-9133dcf0-d6d9-4d24-a217-ae68fdb04475'
+
+# Download the index from Cloud Storage.
+mkdir -p "$SEARCH_DIR"
+gcloud storage cp --project "$GCP_PROJECT_ID" \
+    --recursive "gs://$GCP_BUCKET/data.ms" "$SEARCH_DIR"
+
+exec /bin/meilisearch "--db-path=$SEARCH_DB" "--master-key=$MASTER_KEY"


### PR DESCRIPTION
This new image downloads Meilisearch's index files from Cloud Storage.