### PR TITLE
Remove the hardcoded master key

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -60,9 +60,21 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/search
       - uses: actions/checkout@v4
       - uses: docker/build-push-action@v6
+        id: build
         with:
           file: Dockerfile.search
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: sps-by-the-numbers
+          workload_identity_provider: projects/319988578351/locations/global/workloadIdentityPools/github/providers/github-oidc
+          service_account: github-action-716919134@sps-by-the-numbers.iam.gserviceaccount.com
+      - uses: google-github-actions/deploy-cloudrun@v2
+        if: github.event_name == 'push'
+        with:
+          service: meilisearch-staging
+          image: us-west1-docker.pkg.dev/sps-by-the-numbers/ghcr/sps-by-the-numbers/search@${{ steps.build.outputs.digest }}
+          region: us-west1
 

--- a/Dockerfile.search
+++ b/Dockerfile.search
@@ -3,7 +3,7 @@ FROM getmeili/meilisearch:v1.14
 ARG GOOGLE_CLOUD_CLI_VERSION=522.0.0
 
 RUN <<EOF
-apk add --no-cache python3
+apk add --no-cache python3 jq
 curl --silent https://storage.googleapis.com/cloud-sdk-release/google-cloud-cli-${GOOGLE_CLOUD_CLI_VERSION}-linux-x86_64.tar.gz | tar zxf - -C /opt
 /opt/google-cloud-sdk/install.sh --quiet
 EOF

--- a/tools/search/recreate_index.sh
+++ b/tools/search/recreate_index.sh
@@ -14,12 +14,7 @@ fi
 # Make sure the bucket is accessible, before starting the indexing process.
 gcloud storage ls "gs://$GCP_BUCKET"
 
-# This key is for testing.
-# The key must be at least 16 bytes long.
-# https://www.meilisearch.com/docs/learn/security/basic_security#creating-the-master-key-in-a-self-hosted-instance
-export MASTER_KEY='MEILI-9133dcf0-d6d9-4d24-a217-ae68fdb04475'
-
-nohup /usr/local/bin/meilisearch --db-path=$SEARCH_DB --master-key="$MASTER_KEY" &
+nohup /usr/local/bin/meilisearch --db-path=$SEARCH_DB --master-key="$MEILISEARCH_MASTER_KEY" &
 SEARCH_PID=$!
 
 # Wait until health check comes back with 200.

--- a/tools/search/start_meilisearch.sh
+++ b/tools/search/start_meilisearch.sh
@@ -8,14 +8,9 @@ if [[ -e "$gcp_key_path" ]]; then
     gcloud auth activate-service-account "--key-file=$gcp_key_path"
 fi
 
-# This key is for testing.
-# The key must be at least 16 bytes long.
-# https://www.meilisearch.com/docs/learn/security/basic_security#creating-the-master-key-in-a-self-hosted-instance
-MASTER_KEY='MEILI-9133dcf0-d6d9-4d24-a217-ae68fdb04475'
-
 # Download the index from Cloud Storage.
 mkdir -p "$SEARCH_DIR"
 gcloud storage cp --project "$GCP_PROJECT_ID" \
     --recursive "gs://$GCP_BUCKET/data.ms" "$SEARCH_DIR"
 
-exec /bin/meilisearch "--db-path=$SEARCH_DB" "--master-key=$MASTER_KEY"
+exec /bin/meilisearch "--db-path=$SEARCH_DB" "--master-key=$MEILISEARCH_MASTER_KEY"

--- a/tools/search/start_meilisearch.sh
+++ b/tools/search/start_meilisearch.sh
@@ -4,8 +4,11 @@ set -euo pipefail
 # gcp_key_path is for testing this image outside of Cloud Run.
 # On Cloud Run, permissions are granted via the service account of the job.
 gcp_key_path=/run/secrets/gcp.json
-if [[ -e "$gcp_key_path" ]]; then
+if [ -e "$gcp_key_path" ]; then
     gcloud auth activate-service-account "--key-file=$gcp_key_path"
+else
+  export CLOUDSDK_AUTH_ACCESS_TOKEN=$(curl -s -H "Metadata-Flavor: Google" \
+    "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" | jq -r .access_token)
 fi
 
 # Download the index from Cloud Storage.


### PR DESCRIPTION
Cloud Run can expose Secret Manager's secrets from environment variables.